### PR TITLE
go-sdk: Add some go sdk examples

### DIFF
--- a/sdk-go-examples/README.md
+++ b/sdk-go-examples/README.md
@@ -1,0 +1,22 @@
+1. Get the go-ovirt
+```
+$ go get github.com/ovirt/go-ovirt
+```
+
+2. Go to example dir
+```
+    $ cd network
+```
+
+2. Edit list_networks.go:
+```
+    $ vi list_networks.go
+        1. Change domain: foobar.mydomain.home
+        2. Username
+        3. Password
+```
+3. Execute
+```
+$ go run ./list_networks.go
+  Cluster: Default id: 40285c82-00e0-11ea-acb1-ecf4bbf47b7c networks: [net1 net2 ovirtmgmt]
+```

--- a/sdk-go-examples/cluster/list_clusters.go
+++ b/sdk-go-examples/cluster/list_clusters.go
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2017 Joey <majunjiev@gmail.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func main() {
+	inputRawURL := "https://foobar.mydomain.home/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("mysuperpass").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the "clusters" service:
+	clustersService := conn.SystemService().ClustersService()
+
+	// Use the "list" method of the "clusters" service to list all the clusters of the system:
+	clustersResponse, err := clustersService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to get cluster list, reason: %v\n", err)
+		return
+	}
+
+	if clusters, ok := clustersResponse.Clusters(); ok {
+		// Print the datacenter names and identifiers:
+		for _, cluster := range clusters.Slice() {
+			fmt.Printf("Cluster: (")
+			if clusterName, ok := cluster.Name(); ok {
+				fmt.Printf(" name: %v", clusterName)
+			}
+			if clusterID, ok := cluster.Id(); ok {
+				fmt.Printf(" id: %v", clusterID)
+			}
+			fmt.Println(")")
+		}
+	}
+}

--- a/sdk-go-examples/datacenter/datacenter_list.go
+++ b/sdk-go-examples/datacenter/datacenter_list.go
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2020 Douglas Schilling Landgraf <dougsland@redhat.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"time"
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func main() {
+	inputRawURL := "https://foobar.mydomain.home/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("mysuperpass").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Find all clusters of the data center:
+        dataCentersService := conn.SystemService().DataCentersService()
+        dcsListResp, err := dataCentersService.List().Search("status=up").Send()
+        if err != nil {
+                fmt.Printf("Failed to search dataCenter list, reason: %v\n", err)
+                return
+        }
+	dcs := dcsListResp.MustDataCenters()
+        for _, dc := range dcs.Slice() {
+		dcService := dataCentersService.DataCenterService(dc.MustId())
+		fmt.Println("Datacenter:", dc.MustName())
+		clusters, err := dcService.ClustersService().List().Send()
+		if err != nil {
+			fmt.Printf("Failed to search dataCenter list, reason: %v\n", err)
+			return
+		}
+		clusterSlice := clusters.MustClusters()
+		clusterIds := make(map[string]string, 0)
+		for _, cluster := range clusterSlice.Slice() {
+			clusterIds[cluster.MustId()] = cluster.MustId()
+			fmt.Println("\tCluster:", cluster.MustName())
+		}
+	}
+}

--- a/sdk-go-examples/network/list_networks.go
+++ b/sdk-go-examples/network/list_networks.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2017 Joey <majunjiev@gmail.com>.
+// Copyright (c) 2020 Douglas S Landgraf <dougsland@redhat.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func main() {
+	inputRawURL := "https://engine.medogz.home/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("mysuperpass").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the "clusters" service:
+	clustersService := conn.SystemService().ClustersService()
+
+	// Use the "list" method of the "clusters" service to list all the clusters of the system:
+	clustersResponse, err := clustersService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to get cluster list, reason: %v\n", err)
+		return
+	}
+
+	if clusters, ok := clustersResponse.Clusters(); ok {
+		// Print the datacenter names and identifiers:
+		for _, cluster := range clusters.Slice() {
+			fmt.Printf("Cluster")
+			if clusterName, ok := cluster.Name(); ok {
+				fmt.Printf(": %v", clusterName)
+			}
+			clusterID, ok := cluster.Id()
+			fmt.Printf(" id: %v ", clusterID)
+			var networkByNames = make(map[string]*ovirtsdk4.Network)
+			var networkNames []string
+			systemService := conn.SystemService()
+			networksResponse, err := systemService.ClustersService().ClusterService(clusterID).NetworksService().List().Send()
+			if err != nil {
+				return
+			}
+			networks, ok := networksResponse.Networks()
+			if !ok {
+				fmt.Printf("there are no available networks for cluster %s", clusterID)
+				return
+			}
+
+			for _, network := range networks.Slice() {
+				networkByNames[network.MustName()] = network
+				networkNames = append(networkNames, network.MustName())
+			}
+			fmt.Println("networks:", networkNames)
+		}
+	}
+}

--- a/sdk-go-examples/tags/list_tags.go
+++ b/sdk-go-examples/tags/list_tags.go
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 Douglas Landgraf <dougsland@redhat.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func main() {
+	inputRawURL := "https://engine.mydomain.home/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("mysuperpassword").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	tagsService := conn.SystemService().TagsService()
+	resp, err := tagsService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to get tag list, reason: %v\n", err)
+		return
+	}
+
+	if tagSlice, ok := resp.Tags(); ok {
+		for _, tag := range tagSlice.Slice() {
+			fmt.Printf("Tag: (")
+			if tagName, ok := tag.Name(); ok {
+				fmt.Printf(" name: %v", tagName)
+			}
+			if tagDesc, ok := tag.Description(); ok {
+				fmt.Printf(" desc: %v", tagDesc)
+			}
+			fmt.Println(")")
+		}
+	}
+
+}

--- a/sdk-go-examples/vms/list_vms_with_tag.go
+++ b/sdk-go-examples/vms/list_vms_with_tag.go
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2017 Joey <majunjiev@gmail.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func main() {
+	inputRawURL := "https://engine.medogz.home/ovirt-engine/api"
+	tag := "tag=cluster-ztnq2"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("mysuperpass").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	fmt.Println("looking for vms with tag..")
+	// Get the reference to the "vms" service:
+	vmsService := conn.SystemService().VmsService()
+
+	// Use the "list" method of the "vms" service to list all the virtual machines
+	vmsResponse, err := vmsService.List().Search(tag).Send()
+
+	if err != nil {
+		fmt.Printf("Failed to get vm list, reason: %v\n", err)
+		return
+	}
+	if vms, ok := vmsResponse.Vms(); ok {
+		// Print the virtual machine names and identifiers:
+		for _, vm := range vms.Slice() {
+			fmt.Print("VM: (")
+			if vmName, ok := vm.Name(); ok {
+				fmt.Printf(" name: %v", vmName)
+			}
+			if vmID, ok := vm.Id(); ok {
+				fmt.Printf(" id: %v", vmID)
+			}
+			fmt.Println(")")
+		}
+	}
+}


### PR DESCRIPTION
OCP on RHV uses go sdk. These examples helps on
simulating the installer or debugging.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>