### PR TITLE
doc: adjust README for the new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # ocp-ci-tools
-this repo contains all the tools and automations for ocp-on-rhv CI.
+This repo contains all the engineering tools and useful bits related to ocp-on-rhv.


### PR DESCRIPTION
The repo was about CI only, but now is more generic repo
related to OCP on RHV.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>