### PR TITLE
Modified ocpadmin/readme.md

### DIFF
--- a/installer-tools/ocpadmin/README.md
+++ b/installer-tools/ocpadmin/README.md
@@ -2,7 +2,7 @@
 
 ## Setup user and group on oVirt
 
-The ansible playbook [ovirt_ocp_user-setup.yml](ovirt_ocp_user-setup.yml) helps to setup
+The ansible playbook [ovirt_ocpadmin_user-setup.yml](ovirt_ocpadmin_user-setup.yml) helps to setup
 a user and group with the minimum privileges to run the *openshift-install* on ovirt.
 
 Before running the playbook the following variables should be exported


### PR DESCRIPTION
The [Readme](https://github.com/oVirt/ocp-on-ovirt/blob/master/installer-tools/ocpadmin/README.md) still refers to playbook as `ovirt_ocp_user-setup.yml`, however, the playbook's name has been modified to `ovirt_ocpadmin_user-setup.yml`. This leads to wrong URL while clicking through the Readme.
